### PR TITLE
docs(gh-pages): Uses HashRouter instead of BrowserRouter

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -5,4 +5,5 @@ export default {
   dest: 'docs',
   wrapper: 'site/wrapper.js',
   base: process.env.NODE_ENV === 'production' ? '/audora-ui/' : '/',
+  hashRouter: true,
 }


### PR DESCRIPTION
This PR fixes a bug related to refresh a `docz` site deployed to GitHub Pages.

When deployed to GitHub Pages with `BrowserRouter`, a refresh on a page returns 404.
See https://github.com/pedronauck/docz/issues/25 for reference.

- Current scenario:
If you try to access https://audora.github.io/audora-ui/components/input, it doesn't work because the docs are built with `BrowserRouter`.

- Working scenario:
Using `HashRouter`, https://arthurdenner.github.io/audora-ui/#/components/input works properly.

**PS: You'll need to run the `docz:build` script and deploy the site again after accepting this PR.**